### PR TITLE
本次更新主要是對代碼進行優化和錯誤處理的改進，以及對模型默認值的修正，旨在提升代碼的健壯性和用戶體驗。

### DIFF
--- a/src/switchbot/adapters/iot_api_server.py
+++ b/src/switchbot/adapters/iot_api_server.py
@@ -151,7 +151,8 @@ class SwitchBotApiServer(AbstractIotApiServer):
         for _data in resp_body.get('infraredRemoteList'):
             # assert isinstance(_data, dict)
             # _dev_list.append(model.SwitchBotDevice(**_data))
-            raise NotImplementedError
+            logger.warning(f'INFRARED REMOTE DEVICE NOT SUPPORTED YET: {_data}')
+            # raise NotImplementedError
         return _dev_list
 
     def send_dev_ctrl_cmd(self, secret: str, token: str, dev_id: str, cmd_type: str, cmd_value: str,

--- a/src/switchbot/domain/model.py
+++ b/src/switchbot/domain/model.py
@@ -542,7 +542,7 @@ class SwitchBotDeviceSchema(Schema):
     device_id = fields.String(data_key="deviceId")
     device_name = fields.String(data_key="deviceName")
     device_type = fields.String(data_key="deviceType")
-    enable_cloud_service = fields.Boolean(data_key="enableCloudService")
+    enable_cloud_service = fields.Boolean(data_key="enableCloudService", load_default=False)
     hub_device_id = fields.String(data_key="hubDeviceId")
     curtain_devices_ids = fields.List(fields.String(), data_key="curtainDevicesIds", load_default=None)
     calibrate = fields.Boolean(load_default=None)

--- a/src/switchbot/entrypoints/cli.py
+++ b/src/switchbot/entrypoints/cli.py
@@ -81,10 +81,7 @@ def check(secret, token):
             secret=secret,
             token=token
         )
-        if not r:
-            click.echo('Fail')
-        else:
-            click.echo('OK')
+        click.echo('OK')
     except SwitchBotAPIServerError:
         click.echo(f'Fail')
 


### PR DESCRIPTION
### 分析代碼變更

本次代碼更新主要涉及三個文件：`iot_api_server.py`, `model.py`, 和 `cli.py`。

#### `iot_api_server.py`
1. **新增日誌記錄**: 當處理紅外遙控設備時，原先代碼直接拋出`NotImplementedError`，現在改為記錄一條警告日誌，表明紅外遙控設備暫不支持，並且不再拋出錯誤。

#### `model.py`
1. **修正`enable_cloud_service`默認值**: 在`SwitchBotDevice`模型的`enable_cloud_service`字段中，原先沒有設置`load_default`參數，現在設置其默認值為`False`。這樣當此字段在輸入數據中缺失時，將默認該設備不支持雲服務。

#### `cli.py`
1. **簡化認證狀態檢查輸出**: 在`auth check`命令的處理中，原先會根據返回結果的有無來分別輸出`Fail`或`OK`。現在直接輸出`OK`，只在捕獲到`SwitchBotAPIServerError`時輸出`Fail`。
